### PR TITLE
Feature: Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+
+jdk:
+  - oraclejdk8
+
+cache:
+  directories:
+    - $HOME/.m2/
+
+install:
+  - mvn clean package assembly:single
+


### PR DESCRIPTION
Simple change to add Travis support. It just builds the package and assembles a fat JAR in CI, against JDK 8.