### PR TITLE
Feature: Allow @supports

### DIFF
--- a/src/com/google/common/css/JobDescriptionBuilder.java
+++ b/src/com/google/common/css/JobDescriptionBuilder.java
@@ -55,10 +55,12 @@ public class JobDescriptionBuilder {
   Set<String> allowedNonStandardFunctions;
   boolean allowUnrecognizedProperties;
   Set<String> allowedUnrecognizedProperties;
+  Set<String> allowedAtRules;
   boolean allowUndefinedConstants;
   boolean allowMozDocument;
   Vendor vendor;
   boolean allowKeyframes;
+  boolean allowSupports;
   boolean allowWebkitKeyframes;
   boolean processDependencies;
   String cssRenamingPrefix;
@@ -94,6 +96,7 @@ public class JobDescriptionBuilder {
     this.allowedNonStandardFunctions = Sets.newHashSet();
     this.allowUnrecognizedProperties = false;
     this.allowedUnrecognizedProperties = Sets.newHashSet();
+    this.allowedAtRules = Sets.newHashSet();
     this.allowUndefinedConstants = false;
     this.allowMozDocument = false;
     this.vendor = null;
@@ -131,7 +134,9 @@ public class JobDescriptionBuilder {
     this.allowUnrecognizedFunctions = jobToCopy.allowUnrecognizedFunctions;
     this.allowedNonStandardFunctions =
         ImmutableSet.copyOf(jobToCopy.allowedNonStandardFunctions);
-    this.allowUnrecognizedProperties = jobToCopy.allowUnrecognizedProperties;
+    this.allowedAtRules = Sets.newHashSet(jobToCopy.allowedAtRules);
+    this.allowUnrecognizedProperties =
+        jobToCopy.allowUnrecognizedProperties;
     this.allowedUnrecognizedProperties =
         ImmutableSet.copyOf(jobToCopy.allowedUnrecognizedProperties);
     this.allowUndefinedConstants = jobToCopy.allowUndefinedConstants;
@@ -347,6 +352,13 @@ public class JobDescriptionBuilder {
     return this;
   }
 
+  public JobDescriptionBuilder setAllowAtRules(
+    List<String> atRuleNames) {
+    checkJobIsNotAlreadyCreated();
+    this.allowedAtRules.addAll(atRuleNames);
+    return this;
+  }
+
   public JobDescriptionBuilder allowUnrecognizedProperties() {
     return setAllowUnrecognizedProperties(true);
   }
@@ -370,8 +382,18 @@ public class JobDescriptionBuilder {
     return this;
   }
 
+  public JobDescriptionBuilder setAllowSupports(boolean allow) {
+    checkJobIsNotAlreadyCreated();
+    this.allowSupports = allow;
+    return this;
+  }
+
   public JobDescriptionBuilder allowKeyframes() {
     return setAllowKeyframes(true);
+  }
+
+  public JobDescriptionBuilder allowSupports() {
+    return setAllowSupports(true);
   }
 
   public JobDescriptionBuilder setAllowWebkitKeyframes(boolean allow) {
@@ -470,7 +492,6 @@ public class JobDescriptionBuilder {
       return job;
     }
 
-    Set<String> allowedAtRules = Sets.newHashSet();
     if (allowKeyframes || allowWebkitKeyframes) {
       allowedAtRules.add("keyframes");
       allowedAtRules.add("-moz-keyframes");
@@ -480,6 +501,9 @@ public class JobDescriptionBuilder {
     }
     if (allowMozDocument) {
       allowedAtRules.add("-moz-document");
+    }
+    if (allowSupports) {
+      allowedAtRules.add("supports");
     }
 
 

--- a/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
+++ b/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
@@ -170,6 +170,10 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
         "Specify an unrecognized property to whitelist")
     private List<String> allowedUnrecognizedProperties = Lists.newArrayList();
 
+    @Option(name = "--allowed-at-rule", usage =
+      "Specify an @-rule to whitelist, like @supports")
+    private List<String> additionalAtRules = Lists.newArrayList();
+
     @Option(name = "--allow-unrecognized-properties", usage =
         "Allow unrecognized properties.")
     private boolean allowUnrecognizedProperties = false;
@@ -240,8 +244,10 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
       builder.setAllowedNonStandardFunctions(allowedNonStandardFunctions);
       builder.setAllowedUnrecognizedProperties(allowedUnrecognizedProperties);
       builder.setAllowUnrecognizedProperties(allowUnrecognizedProperties);
+      builder.setAllowAtRules(additionalAtRules);
       builder.setVendor(vendor);
       builder.setAllowKeyframes(true);
+      builder.setAllowSupports(true);
       builder.setAllowWebkitKeyframes(true);
       builder.setProcessDependencies(true);
       builder.setExcludedClassesFromRenaming(excludedClassesFromRenaming);


### PR DESCRIPTION
This changeset makes a small modification to Closure Stylesheets, to allow the 'supports' at-rule in CSS. Additionally, it adds a command line flag (`--allowed-at-rule`) to whitelist at-rules as needed in the future.

Changes:
- [x] Add support for `--allowed-at-rule`
- [x] Enable support by default for the `@supports` tag
- [x] Unit test support
  - [x] `@supports` tag