### PR TITLE
Implemented Math.pow to GSS.

### DIFF
--- a/src/com/google/common/css/compiler/gssfunctions/GssFunctions.java
+++ b/src/com/google/common/css/compiler/gssfunctions/GssFunctions.java
@@ -72,6 +72,7 @@ public class GssFunctions {
         .put("divide", new GssFunctions.Div())
         .put("minimum", new GssFunctions.MinValue())
         .put("maximum", new GssFunctions.MaxValue())
+        .put("pow", new Pow())
 
         // Color functions.
         .put("blendColorsHsb", new BlendColorsHsb())
@@ -1693,5 +1694,13 @@ public class GssFunctions {
     checkSize(size, units, null /* errorManager */, null /* location */,
         isUnitOptional);
     return new Size(size, units);
+  }
+
+  public static class Pow extends ScalarLeftAssociativeOperator {
+
+    @Override
+    protected double performOperation(double left, double right) {
+      return Math.pow(left, right);
+    }
   }
 }

--- a/tests/com/google/common/css/compiler/gssfunctions/GssFunctionsTest.java
+++ b/tests/com/google/common/css/compiler/gssfunctions/GssFunctionsTest.java
@@ -112,6 +112,38 @@ public class GssFunctionsTest {
         .isEqualTo("103.06748466");
   }
 
+    @Test
+    public void testPowGetCallResultString() throws GssFunctionException {
+        GssFunctions.Pow funct = new GssFunctions.Pow();
+        assertThat(funct.getCallResultString(ImmutableList.of("60px", "2"))).isEqualTo("3600px");
+        assertThat(funct.getCallResultString(ImmutableList.of("60px", "-2"))).isEqualTo("0.00027778px");
+        assertThat(funct.getCallResultString(ImmutableList.of("83px", "6.4")))
+                .isEqualTo("1914695828969.711px");
+        assertThat(funct.getCallResultString(ImmutableList.of("30%", "2"))).isEqualTo("900%");
+    }
+
+    @Test
+    public void testPowGetCallResultString_otherLocale() throws GssFunctionException {
+        Locale.setDefault(Locale.FRANCE);
+        try {
+            GssFunctions.Pow funct = new GssFunctions.Pow();
+          assertThat(funct.getCallResultString(ImmutableList.of("83px", "6.4")))
+                  .isEqualTo("1914695828969.711px");
+        } finally {
+            Locale.setDefault(Locale.US);
+        }
+    }
+
+    @Test
+    public void testPowGetCallResultString_noUnits() throws GssFunctionException {
+      GssFunctions.Pow funct = new GssFunctions.Pow();
+      assertThat(funct.getCallResultString(ImmutableList.of("60", "2"))).isEqualTo("3600");
+      assertThat(funct.getCallResultString(ImmutableList.of("60", "-2"))).isEqualTo("0.00027778");
+      assertThat(funct.getCallResultString(ImmutableList.of("83", "6.4")))
+              .isEqualTo("1914695828969.711");
+      assertThat(funct.getCallResultString(ImmutableList.of("30", "2"))).isEqualTo("900");
+    }
+
   @Test
   public void testMaxGetCallResultString() throws GssFunctionException {
     GssFunctions.MaxValue funct = new GssFunctions.MaxValue();
@@ -151,6 +183,11 @@ public class GssFunctionsTest {
     testFunctionCallFail(div, ImmutableList.of("42", "2px"));
     testFunctionCallFail(div, ImmutableList.of("42px", "2px"));
     testFunctionCallFail(div, ImmutableList.of("42px", "2em"));
+
+    GssFunctions.Pow pow = new GssFunctions.Pow();
+    testFunctionCallFail(pow, ImmutableList.of("42", "2px"));
+    testFunctionCallFail(pow, ImmutableList.of("42px", "2px"));
+    testFunctionCallFail(pow, ImmutableList.of("42px", "2em"));
   }
 
   @Test


### PR DESCRIPTION
# Use Case
Let's say I'm implementing a GUI which has a reference value X, and all other measures (width, height, etc.) are calculated based on the reference value, using the golden ratio, of an nth iteration :
```
Golden Ratio ($GR) : 1.61803398875
Reference value ($REF) : 800px;
Intended height : $REF / $GR
Split content in 2 columns, where
   Column 1 width  : 800 / ($GR^3) 
  Column 2 widrth : the rest of the space
```
Right now my workaround is to just do `mult(GR, GR, GR, GR, ... <nth>GR)` when wanting to do GR^n, but that's quite clumsy.

This implementation intends to provide a `pow` function where I can say `pow(GR, n)`