### PR TITLE
Property: font-smooth

### DIFF
--- a/src/com/google/common/css/compiler/ast/Property.java
+++ b/src/com/google/common/css/compiler/ast/Property.java
@@ -205,6 +205,7 @@ public final class Property {
         builder("font-language-override"),
         builder("font-size"),
         builder("font-size-adjust"),
+        builder("font-smooth"),
         builder("font-stretch"),
         builder("font-style"),
         builder("font-synthesis"),


### PR DESCRIPTION
This changeset adds support for [`font-smooth`](https://sass-lang.com/documentation/at-rules/mixin)
in GSS.